### PR TITLE
add support for hashed emails as input param

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ After importing the `GravatarModule`, you can use the `ngxGravatar` directive in
 
 ```html
 <img ngxGravatar [email]="'example@mail.com'">
+<img ngxGravatar [email]="'fbf2b9cfc0a472389f3620e471bdf0e9'">
 <img ngxGravatar [email]="'example@mail.com'" size="30">
 <img ngxGravatar [email]="'example@mail.com'" size="30" src="assets/avatar.jpg">
 <img ngxGravatar [email]="'example@mail.com'" size="30" src="assets/avatar.jpg" [style]="styleObject">
@@ -88,7 +89,7 @@ After importing the `GravatarModule`, you can use the `ngxGravatar` directive in
 
 |   Attribute   |      Type      | Required  | Default |                                              Description                   											|
 | ------------- | ----------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------- |
-| `email`          | *string*  | requried | (*empty string*)| Email associated with Gravatar                      																				|
+| `email`          | *string*  | requried | (*empty string*)| Email or hash of email associated with Gravatar                                                |
 | `src`            | *string*  | optional |              | Custom image to use                               																							|
 | `preferGravatar` | *boolean* | optional | `false`      | If `true`, Gravatar will have higher priority. Otherwise, `src` image will be loaded first.    |
 | `size`           | *number*  | optional | `40`         | Displayed size of the avatar                                                                             |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ After importing the `GravatarModule`, you can use the `ngxGravatar` directive in
 
 ```html
 <img ngxGravatar [email]="'example@mail.com'">
-<img ngxGravatar [email]="'fbf2b9cfc0a472389f3620e471bdf0e9'">
+<img ngxGravatar [md5Hash]="'fbf2b9cfc0a472389f3620e471bdf0e9'">
 <img ngxGravatar [email]="'example@mail.com'" size="30">
 <img ngxGravatar [email]="'example@mail.com'" size="30" src="assets/avatar.jpg">
 <img ngxGravatar [email]="'example@mail.com'" size="30" src="assets/avatar.jpg" [style]="styleObject">
@@ -89,7 +89,8 @@ After importing the `GravatarModule`, you can use the `ngxGravatar` directive in
 
 |   Attribute   |      Type      | Required  | Default |                                              Description                   											|
 | ------------- | ----------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------- |
-| `email`          | *string*  | requried | (*empty string*)| Email or hash of email associated with Gravatar                                                |
+| `email`          | *string*  | requried | (*empty string*)| Email associated with Gravatar, either this attribute or `md5Hash` must be set |
+| `md5Hash`        | *string*  | requried | (*empty string*)| MD5 hash of email associated with Gravatar, either this attribute or `email` must be set |
 | `src`            | *string*  | optional |              | Custom image to use                               																							|
 | `preferGravatar` | *boolean* | optional | `false`      | If `true`, Gravatar will have higher priority. Otherwise, `src` image will be loaded first.    |
 | `size`           | *number*  | optional | `40`         | Displayed size of the avatar                                                                             |

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.directive.spec.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.directive.spec.ts
@@ -9,6 +9,7 @@ import { FALLBACK, RATING } from './ngx-gravatar.enums';
 
 @Component({
   template: `<img ngxGravatar [email]="email"
+                              [md5Hash]="md5Hash"
                               [src]="src"
                               [preferGravatar]="preferGravatar"
                               [size]="size"
@@ -25,6 +26,7 @@ import { FALLBACK, RATING } from './ngx-gravatar.enums';
 })
 class TestNgxGravatarComponent {
   email: string;
+  md5Hash: string;
   src: string;
   preferGravatar: boolean;
   size: number;
@@ -90,8 +92,8 @@ describe('NgxGravatarDirective', () => {
     expect(imgEl.getAttribute('src')).toBe('//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=80&r=g&d=retro');
   });
 
-  it('Setting email="0a2aaae0ac1310d1f8e8e68df45fe7b8", src should be gravatar url', () => {
-    component.email = '0a2aaae0ac1310d1f8e8e68df45fe7b8';
+  it('Setting md5Hash="0a2aaae0ac1310d1f8e8e68df45fe7b8", src should be gravatar url', () => {
+    component.md5Hash = '0a2aaae0ac1310d1f8e8e68df45fe7b8';
     fixture.detectChanges();
     expect(imgEl.getAttribute('src')).toBe('//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=80&r=g&d=retro');
   });

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.directive.spec.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.directive.spec.ts
@@ -90,6 +90,12 @@ describe('NgxGravatarDirective', () => {
     expect(imgEl.getAttribute('src')).toBe('//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=80&r=g&d=retro');
   });
 
+  it('Setting email="0a2aaae0ac1310d1f8e8e68df45fe7b8", src should be gravatar url', () => {
+    component.email = '0a2aaae0ac1310d1f8e8e68df45fe7b8';
+    fixture.detectChanges();
+    expect(imgEl.getAttribute('src')).toBe('//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=80&r=g&d=retro');
+  });
+
   it('Setting src="https://github.com/t-ho/ngx-gravatar/blob/master/src/assets/avatar.jpg?raw=true", '
     + 'src should be "https://github.com/t-ho/ngx-gravatar/blob/master/src/assets/avatar.jpg?raw=true"', () => {
     component.src = 'https://github.com/t-ho/ngx-gravatar/blob/master/src/assets/avatar.jpg?raw=true';

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.directive.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.directive.ts
@@ -8,6 +8,7 @@ import { GravatarConfig } from './gravatar-config';
 export class NgxGravatarDirective implements OnChanges, OnInit {
   @Input() src: string;
   @Input() email: string;
+  @Input() md5Hash: string;
   @Input() size: number;
   @Input() fallback: string; // enum: ['blank', 'identicon', 'mm', 'monsterid', 'retro', 'robohash', 'wavatar']
   @Input() rating: string; // enum: ['g', 'pg', 'r', 'x']
@@ -69,12 +70,12 @@ export class NgxGravatarDirective implements OnChanges, OnInit {
     this.setDefaultValues();
     let url = '';
     if (this.preferGravatar || forcedGravatar) {
-      url = this.gravatarService.generateGravatarUrl(this.email, this.requestedSize, this.rating, this.fallback);
+      url = this.gravatarService.generateGravatarUrl(this.email, this.md5Hash, this.requestedSize, this.rating, this.fallback);
     } else { // this.preferGravatar == false
       if (this.src) {
         url = this.src;
       } else { // fallback to gravatar
-        url = this.gravatarService.generateGravatarUrl(this.email, this.requestedSize, this.rating, this.fallback);
+        url = this.gravatarService.generateGravatarUrl(this.email, this.md5Hash, this.requestedSize, this.rating, this.fallback);
       }
     }
     this.renderer.setProperty(this.elementRef.nativeElement, 'src', url);

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.service.spec.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.service.spec.ts
@@ -98,8 +98,8 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
         + `&d=${gravatarService.getDefaultConfig().fallback}`);
   });
 
-  it(`#generateGravatarUrl('0a2aaae0ac1310d1f8e8e68df45fe7b8') should return url with default size, rating, fallback`, () => {
-    expect(gravatarService.generateGravatarUrl('0a2aaae0ac1310d1f8e8e68df45fe7b8'))
+  it(`#generateGravatarUrl(null, '0a2aaae0ac1310d1f8e8e68df45fe7b8') should return url with default size, rating, fallback`, () => {
+    expect(gravatarService.generateGravatarUrl(null, '0a2aaae0ac1310d1f8e8e68df45fe7b8'))
       .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8`
         + `?s=${gravatarService.getDefaultConfig().size}`
         + `&r=${gravatarService.getDefaultConfig().rating}`
@@ -117,8 +117,8 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
     });
   });
 
-  it(`#generateGravatarUrl('toan.hmt@gmail.com', 150) should return url with default rating, fallback and NOT PRINT error message`, () => {
-    expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 150))
+  it(`#generateGravatarUrl('toan.hmt@gmail.com', null, 150) should return url with default rating, fallback and NOT PRINT error message`, () => {
+    expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 150))
       .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=150`
         + `&r=${gravatarService.getDefaultConfig().rating}`
         + `&d=${gravatarService.getDefaultConfig().fallback}`);
@@ -126,10 +126,10 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
   });
 
   validRatings.forEach(rating => {
-    const stmt = `#generateGravatarUrl('toan.hmt@gmail.com', 150, '${rating}') `
+    const stmt = `#generateGravatarUrl('toan.hmt@gmail.com', null, 150, '${rating}') `
       + `should return url with lowercase rating, default fallback and NOT PRINT error message`;
     it(stmt, () => {
-      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 150, rating))
+      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 150, rating))
         .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=150`
           + `&r=${rating.toLowerCase()}`
           + `&d=${gravatarService.getDefaultConfig().fallback}`);
@@ -137,9 +137,9 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
     });
   });
 
-  it(`#generateGravatarUrl('toan.hmt@gmail.com', 380, undefined) `
+  it(`#generateGravatarUrl('toan.hmt@gmail.com', null, 380, undefined) `
       + `should return url with default rating, fallback and NOT PRINT error message`, () => {
-    expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 380, undefined))
+    expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 380, undefined))
       .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=380`
         + `&r=${gravatarService.getDefaultConfig().rating}`
         + `&d=${gravatarService.getDefaultConfig().fallback}`);
@@ -147,10 +147,10 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
   });
 
   invalidRatings.forEach(rating => {
-    const statment = `#generateGravatarUrl('toan.hmt@gmail.com', 150, '${rating}') `
+    const statment = `#generateGravatarUrl('toan.hmt@gmail.com', null, 150, '${rating}') `
       + `should return url with default rating, fallback and PRINT error message`;
     it(statment, () => {
-      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 150, rating))
+      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 150, rating))
         .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=150`
           + `&r=${gravatarService.getDefaultConfig().rating}`
           + `&d=${gravatarService.getDefaultConfig().fallback}`);
@@ -159,28 +159,28 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
   });
 
   validFallbacks.forEach(fallback => {
-    const statment = `#generateGravatarUrl('toan.hmt@gmail.com', 50, 'pg', '${fallback}') `
+    const statment = `#generateGravatarUrl('toan.hmt@gmail.com', null, 50, 'pg', '${fallback}') `
       + `should return specified parameters and NOT PRINT error message`;
     it(statment, () => {
-      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 50, 'pg', fallback))
+      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 50, 'pg', fallback))
         .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=50&r=pg&d=${fallback}`);
       expect(console.error).not.toHaveBeenCalledWith(generateFallbackErrorMessage(fallback, gravatarService.getDefaultConfig().fallback));
     });
   });
 
-  it(`#generateGravatarUrl('toan.hmt@gmail.com', 380, 'pg', undefined) `
+  it(`#generateGravatarUrl('toan.hmt@gmail.com', null, 380, 'pg', undefined) `
       + `should return url with default fallback and NOT PRINT error message`, () => {
-    expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 380, 'pg', undefined))
+    expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 380, 'pg', undefined))
       .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=380&r=pg`
         + `&d=${gravatarService.getDefaultConfig().fallback}`);
     expect(console.error).not.toHaveBeenCalledWith(generateFallbackErrorMessage(undefined, gravatarService.getDefaultConfig().fallback));
   });
 
   invalidFallbacks.forEach(fallback => {
-    const statment = `#generateGravatarUrl('toan.hmt@gmail.com', 50, 'pg', '${fallback}') `
+    const statment = `#generateGravatarUrl('toan.hmt@gmail.com', null, 50, 'pg', '${fallback}') `
       + `should return url with default fallback and PRINT error message`;
     it(statment, () => {
-      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', 50, 'pg', fallback))
+      expect(gravatarService.generateGravatarUrl('toan.hmt@gmail.com', null, 50, 'pg', fallback))
         .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8?s=50&r=pg`
           + `&d=${gravatarService.getDefaultConfig().fallback}`);
       expect(console.error).toHaveBeenCalledWith(generateFallbackErrorMessage(fallback, gravatarService.getDefaultConfig().fallback));

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.service.spec.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.service.spec.ts
@@ -98,6 +98,14 @@ describe('NgxGravatarService with DEFAULT_CONFIG', () => {
         + `&d=${gravatarService.getDefaultConfig().fallback}`);
   });
 
+  it(`#generateGravatarUrl('0a2aaae0ac1310d1f8e8e68df45fe7b8') should return url with default size, rating, fallback`, () => {
+    expect(gravatarService.generateGravatarUrl('0a2aaae0ac1310d1f8e8e68df45fe7b8'))
+      .toEqual(`//www.gravatar.com/avatar/0a2aaae0ac1310d1f8e8e68df45fe7b8`
+        + `?s=${gravatarService.getDefaultConfig().size}`
+        + `&r=${gravatarService.getDefaultConfig().rating}`
+        + `&d=${gravatarService.getDefaultConfig().fallback}`);
+  });
+
   notStrings.forEach(notString => {
     it(`#generateGravatarUrl(${notString}) should return url with default hash, size, rating, fallback and PRINT error message`, () => {
       expect(gravatarService.generateGravatarUrl(notString))

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.service.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.service.ts
@@ -31,36 +31,30 @@ export class NgxGravatarService {
 
   /**
    * Generate gravatar url
-   * @param emailOrHash is a string. If value is not a string, an empty string "" is used by default.
-   * If it is already a hash value it is used as it is otherwise a hash value will be generated.
+   * @param email is a string. If email is not a string, email will be set to empty string "" by default
+   * @param md5Hash is a string. If value is given it will take precedence over email.
    * @param size number
    * @param rating string
    * @param fallback string
    * @return gravatar url
    */
-  generateGravatarUrl(emailOrHash: string, size?: number, rating?: string, fallback?: string) {
-    let isHashed = false;
-    try {
-      emailOrHash = emailOrHash.trim();
-      if (this.isMD5(emailOrHash)) {
-        isHashed = true;
-      } else {
-        emailOrHash = emailOrHash.toLowerCase();
+  generateGravatarUrl(email: string, md5Hash?: string, size?: number, rating?: string, fallback?: string) {
+    let emailHash: string | Int32Array;
+    if (md5Hash) {
+      emailHash = md5Hash;
+    } else {
+      try {
+        email = email.trim().toLowerCase();
+      } catch (e) {
+        console.error(`[ngx-gravatar] - Email (${email}) is not a string. Empty string is used as a default email.`);
+        email = '';
       }
-    } catch (e) {
-      // Complain email is not a string
-      console.error(`[ngx-gravatar] - Email (${emailOrHash}) is not a string. Empty string is used as a default email.`);
-      emailOrHash = '';
+      emailHash = Md5.hashStr(email);
     }
     size = size ? size : this.defaultConfig.size;
     rating = this.determineRating(rating, this.defaultConfig.rating);
     fallback = this.determineFallback(fallback, this.defaultConfig.fallback);
-    const emailHash = isHashed ? emailOrHash : Md5.hashStr(emailOrHash);
     return `//www.gravatar.com/avatar/${emailHash}?s=${size}&r=${rating}&d=${fallback}`;
-  }
-
-  private isMD5(value: string) {
-    return (/[a-fA-F0-9]{32}/).test(value);
   }
 
   /**

--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.service.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.service.ts
@@ -31,25 +31,36 @@ export class NgxGravatarService {
 
   /**
    * Generate gravatar url
-   * @param email is a string. If email is not a string, email will be set to empty string "" by default
+   * @param emailOrHash is a string. If value is not a string, an empty string "" is used by default.
+   * If it is already a hash value it is used as it is otherwise a hash value will be generated.
    * @param size number
    * @param rating string
    * @param fallback string
    * @return gravatar url
    */
-  generateGravatarUrl(email: string, size?: number, rating?: string, fallback?: string) {
+  generateGravatarUrl(emailOrHash: string, size?: number, rating?: string, fallback?: string) {
+    let isHashed = false;
     try {
-      email = email.trim().toLowerCase();
+      emailOrHash = emailOrHash.trim();
+      if (this.isMD5(emailOrHash)) {
+        isHashed = true;
+      } else {
+        emailOrHash = emailOrHash.toLowerCase();
+      }
     } catch (e) {
       // Complain email is not a string
-      console.error(`[ngx-gravatar] - Email (${email}) is not a string. Empty string is used as a default email.`);
-      email = '';
+      console.error(`[ngx-gravatar] - Email (${emailOrHash}) is not a string. Empty string is used as a default email.`);
+      emailOrHash = '';
     }
     size = size ? size : this.defaultConfig.size;
     rating = this.determineRating(rating, this.defaultConfig.rating);
     fallback = this.determineFallback(fallback, this.defaultConfig.fallback);
-    const emailHash = Md5.hashStr(email);
+    const emailHash = isHashed ? emailOrHash : Md5.hashStr(emailOrHash);
     return `//www.gravatar.com/avatar/${emailHash}?s=${size}&r=${rating}&d=${fallback}`;
+  }
+
+  private isMD5(value: string) {
+    return (/[a-fA-F0-9]{32}/).test(value);
   }
 
   /**


### PR DESCRIPTION
Passing a hashed email instead of a unhashed value won't hash it again. This resolves #5.