### PR TITLE
Remove deep imports into `ts-md5`

### DIFF
--- a/projects/ngx-gravatar/src/lib/ngx-gravatar.service.ts
+++ b/projects/ngx-gravatar/src/lib/ngx-gravatar.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
-import { Md5 } from 'ts-md5/dist/md5';
+import { Md5 } from 'ts-md5';
 import { GravatarConfig } from './gravatar-config';
 import { GRAVATAR_CONFIG_TOKEN } from './gravatar-config.token';
 import { DEFAULT_CONFIG } from './ngx-gravatar.constants';


### PR DESCRIPTION
Angular 10 compiler doesn't seem to like the deep imports anymore.

```log
Warning: Entry point 'ngx-gravatar' contains deep imports into 'E:/Repos/repro/node_modules/ts-md5/dist/md5'.
This is probably not a problem, but may cause the compilation of entry points to be out of order.
```